### PR TITLE
Added "no-seeds" option

### DIFF
--- a/internal-messages/permissions.json
+++ b/internal-messages/permissions.json
@@ -2,5 +2,6 @@
   "base-permission": "farmassist.",
   "update-notify": "farmassist.notify.update",
   "till": "farmassist.till",
-  "wheat": "farmassist.wheat"
+  "wheat": "farmassist.wheat",
+  "no-seeds": "farmassist.noseeds"
 }

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.sarhatabaot</groupId>
     <artifactId>farmassistreboot</artifactId>
-    <version>1.3.3</version>
+    <version>1.4.0-SNAPSHOT</version>
 
     <name>FarmAssistReboot</name>
     <description>Allow players to auto-replant crops.</description>

--- a/src/main/java/com/github/sarhatabaot/farmassistreboot/Util.java
+++ b/src/main/java/com/github/sarhatabaot/farmassistreboot/Util.java
@@ -2,6 +2,7 @@ package com.github.sarhatabaot.farmassistreboot;
 
 import com.github.sarhatabaot.farmassistreboot.config.FarmAssistConfig;
 import com.github.sarhatabaot.farmassistreboot.messages.Debug;
+import com.github.sarhatabaot.farmassistreboot.messages.Permissions;
 import com.github.sarhatabaot.farmassistreboot.tasks.ReplantTask;
 import de.tr7zw.changeme.nbtapi.NBTItem;
 import me.clip.placeholderapi.PlaceholderAPI;
@@ -81,22 +82,23 @@ public class Util {
     public static void replant(@NotNull Player player, Block block, @NotNull Material material) {
         Crop crop = Crop.valueOf(material.name());
         int spot = player.getInventory().first(crop.getSeed());
-        debug("Spot:" + spot);
-        if (spot >= 0) {
-            removeOrSubtractItem(player, spot);
-            new ReplantTask(block, plugin).runTaskLater(plugin, 5L);
-        }
+        replant(player, block, spot);
     }
 
     public static void replant(@NotNull Player player, Block block, int spot) {
         debug("Spot:" + spot);
-        if (spot >= 0) {
+        debug("CONFIG:no-seeds: %b, PERMISSION:farmassist.no_seeds: %b", FarmAssistConfig.NO_SEEDS, player.hasPermission(Permissions.NO_SEEDS));
+        if (spot >= 0 || Util.checkNoSeeds(player)) {
             removeOrSubtractItem(player, spot);
             new ReplantTask(block, plugin).runTaskLater(plugin, 5L);
         }
     }
 
     public static void removeOrSubtractItem(@NotNull Player player, int spot) {
+        if(Util.checkNoSeeds(player)) {
+            return;
+        }
+
         ItemStack next = player.getInventory().getItem(spot);
         if (next != null && next.getAmount() > 1) {
             next.setAmount(next.getAmount() - 1);
@@ -125,5 +127,15 @@ public class Util {
     @Contract("_ -> new")
     public static @NotNull String color(final String message) {
         return ChatColor.translateAlternateColorCodes('&', message);
+    }
+
+    /**
+     * Checks if the "no-seeds" config option is enabled
+     * or if the player has the "no-seeds" permission.
+     * @param player Player to check
+     * @return true if the config option is enabled or if the player has the permission
+     */
+    public static boolean checkNoSeeds(final Player player) {
+        return FarmAssistConfig.NO_SEEDS || player.hasPermission(Permissions.NO_SEEDS);
     }
 }

--- a/src/main/java/com/github/sarhatabaot/farmassistreboot/config/FarmAssistConfig.java
+++ b/src/main/java/com/github/sarhatabaot/farmassistreboot/config/FarmAssistConfig.java
@@ -27,6 +27,8 @@ public class FarmAssistConfig {
     public static boolean IGNORE_NBT;
     public static String ACTIVE_LANGUAGE;
 
+    public static boolean NO_SEEDS;
+
 
     public FarmAssistConfig(final @NotNull FarmAssistReboot plugin) {
         this.plugin = plugin;
@@ -41,6 +43,7 @@ public class FarmAssistConfig {
         ACTIVE_LANGUAGE = config.getString("language", "en");
         IGNORE_RENAMED = config.getBoolean("ignore-seeds.renamed", true);
         IGNORE_NBT = config.getBoolean("ignore-seeds.nbt", true);
+        NO_SEEDS = config.getBoolean("no-seeds", false);
     }
 
     public void reloadConfig() {

--- a/src/main/java/com/github/sarhatabaot/farmassistreboot/listeners/BlockBreakListener.java
+++ b/src/main/java/com/github/sarhatabaot/farmassistreboot/listeners/BlockBreakListener.java
@@ -75,7 +75,7 @@ public class BlockBreakListener implements Listener {
 		}
 
 		int slot = Util.inventoryContainsSeeds(event.getPlayer().getInventory(), material);
-		if (slot == -1) {
+		if (!Util.checkNoSeeds(event.getPlayer()) && slot == -1) {
 			debug(Debug.OnBlockBreak.NO_SEEDS,event.getPlayer().getName());
 			return;
 		}

--- a/src/main/java/com/github/sarhatabaot/farmassistreboot/messages/Permissions.java
+++ b/src/main/java/com/github/sarhatabaot/farmassistreboot/messages/Permissions.java
@@ -5,6 +5,7 @@ public final class Permissions {
     public static final String UPDATE_NOTIFY = "farmassist.notify.update";
     public static final String TILL = "farmassist.till";
     public static final String WHEAT = "farmassist.wheat";
+    public static final String NO_SEEDS = "farmassist.noseeds";
 
     private Permissions() {
         throw new UnsupportedOperationException(Debug.UTIL_CLASS);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -12,6 +12,9 @@ use-permissions: true
 ignore-seeds:
     renamed: true
     nbt: true
+# Setting this to true will make it so players are no longer required to have seeds in their inventory to replant.
+# Want to have this per player? Set this to false and give them the permission "farmassit.noseeds"
+no-seeds: false
 # Even if you give the permission these settings will override it.
 # Example:
 # player has farmassist.wheat

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -46,3 +46,5 @@ permissions:
     default: op
   farmassist.lang:
     default: op
+  farmassist.noseeds:
+    default: false


### PR DESCRIPTION
This implements #43 

Added config option: `no-seeds` that is set to false by default
Added permission: `farmassist.noseeds` that is set to false by default