### PR TITLE
Fix multiple bugs: PITCHER_CROP enum, permission logic, seed filters, thread safety

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,6 +89,6 @@ tasks {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(8))
+        languageVersion.set(JavaLanguageVersion.of(25))
     }
 }

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,0 +1,48 @@
+#-------------------------------------------------------------------------------#
+#               Qodana analysis is configured by qodana.yaml file               #
+#             https://www.jetbrains.com/help/qodana/qodana-yaml.html            #
+#-------------------------------------------------------------------------------#
+
+#################################################################################
+#              WARNING: Do not store sensitive information in this file,        #
+#               as its contents will be included in the Qodana report.          #
+#################################################################################
+version: "1.0"
+
+#Specify inspection profile for code analysis
+profile:
+  name: qodana.starter
+
+#Enable inspections
+#include:
+#  - name: <SomeEnabledInspectionId>
+
+#Disable inspections
+#exclude:
+#  - name: <SomeDisabledInspectionId>
+#    paths:
+#      - <path/where/not/run/inspection>
+
+projectJDK: "25" #(Applied in CI/CD pipeline)
+
+#Execute shell command before Qodana execution (Applied in CI/CD pipeline)
+#bootstrap: sh ./prepare-qodana.sh
+
+#Install IDE plugins before Qodana execution (Applied in CI/CD pipeline)
+#plugins:
+#  - id: <plugin.id> #(plugin id can be found at https://plugins.jetbrains.com)
+
+# Quality gate. Will fail the CI/CD pipeline if any condition is not met
+# severityThresholds - configures maximum thresholds for different problem severities
+# testCoverageThresholds - configures minimum code coverage on a whole project and newly added code
+# Code Coverage is available in Ultimate and Ultimate Plus plans
+#failureConditions:
+#  severityThresholds:
+#    any: 15
+#    critical: 5
+#  testCoverageThresholds:
+#    fresh: 70
+#    total: 50
+
+#Specify Qodana linter for analysis (Applied in CI/CD pipeline)
+linter: jetbrains/qodana-jvm:2026.1

--- a/src/main/java/com/github/sarhatabaot/farmassistreboot/Crop.java
+++ b/src/main/java/com/github/sarhatabaot/farmassistreboot/Crop.java
@@ -5,7 +5,8 @@ import com.cryptomorin.xseries.XMaterial;
 import org.bukkit.Material;
 
 import java.util.Arrays;
-import java.util.List;
+import java.util.Collections;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public enum Crop {
@@ -18,7 +19,14 @@ public enum Crop {
     BEETROOTS(new XMaterial[]{XMaterial.FARMLAND}, XMaterial.BEETROOTS, XMaterial.BEETROOT_SEEDS),
     CACTUS(new XMaterial[]{XMaterial.SAND}, XMaterial.CACTUS, XMaterial.CACTUS),
     TORCHFLOWER(new XMaterial[]{XMaterial.FARMLAND}, XMaterial.TORCHFLOWER, XMaterial.TORCHFLOWER_SEEDS),
-    PITCHER_PLANT(new XMaterial[]{XMaterial.FARMLAND}, XMaterial.PITCHER_CROP, XMaterial.PITCHER_POD);
+    PITCHER_CROP(new XMaterial[]{XMaterial.FARMLAND}, XMaterial.PITCHER_CROP, XMaterial.PITCHER_POD);
+
+    private static final Set<Material> CROP_MATERIALS = Collections.unmodifiableSet(
+            Arrays.stream(Crop.values())
+                    .map(crop -> crop.planted.parseMaterial())
+                    .filter(m -> m != null)
+                    .collect(Collectors.toSet())
+    );
 
     private final XMaterial[] plantedOn;
     private final XMaterial planted;
@@ -31,8 +39,8 @@ public enum Crop {
         this.seed = seed;
     }
 
-    public static List<Material> getCropList() {
-        return Arrays.stream(Crop.values()).map(crop -> crop.planted.parseMaterial()).collect(Collectors.toList());
+    public static Set<Material> getCropList() {
+        return CROP_MATERIALS;
     }
 
     public XMaterial[] getPlantedOn() {

--- a/src/main/java/com/github/sarhatabaot/farmassistreboot/FarmAssistPlaceholderExpansion.java
+++ b/src/main/java/com/github/sarhatabaot/farmassistreboot/FarmAssistPlaceholderExpansion.java
@@ -39,14 +39,15 @@ public class FarmAssistPlaceholderExpansion extends PlaceholderExpansion {
         }
         
         if (params.startsWith("player_")) {
-            final String name = params.split("_")[1];
-            if (name != null) {
-                final UUID uuid = getUuid(name);
-                if (uuid == null)
-                    return "";
-                
-                return isFarmAssistEnabledForUuid(uuid);
+            final String[] parts = params.split("_", 2);
+            if (parts.length < 2 || parts[1].isEmpty()) {
+                return null;
             }
+            final String name = parts[1];
+            final UUID uuid = getUuid(name);
+            if (uuid == null)
+                return "";
+            return isFarmAssistEnabledForUuid(uuid);
         }
         
         

--- a/src/main/java/com/github/sarhatabaot/farmassistreboot/FarmAssistReboot.java
+++ b/src/main/java/com/github/sarhatabaot/farmassistreboot/FarmAssistReboot.java
@@ -14,35 +14,36 @@ import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 import space.arim.morepaperlib.MorePaperLib;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * @author sarhatabaot
  */
 public class FarmAssistReboot extends JavaPlugin {
     private final MorePaperLib paperLib = new MorePaperLib(this);
-    private final List<UUID> disabledPlayerList = new ArrayList<>();
+    private final List<UUID> disabledPlayerList = new CopyOnWriteArrayList<>();
     private FarmAssistConfig assistConfig;
     private LanguageManager languageManager;
 
-    private boolean globalEnabled;
+    private volatile boolean globalEnabled;
 
-    private boolean needsUpdate;
-    private String newVersion;
+    private volatile boolean needsUpdate;
+    private volatile String newVersion;
 
     @Override
     public void onEnable() {
         saveDefaultConfig();
         this.assistConfig = new FarmAssistConfig(this);
+        if (!isEnabled()) return;
         this.languageManager = new LanguageManager(this);
 
         this.globalEnabled = true;
 
         PaperCommandManager commandManager = new PaperCommandManager(this);
         commandManager.registerCommand(new FarmAssistCommand(this));
-        commandManager.getCommandCompletions().registerCompletion("supported-lang", c -> languageManager.getSupportedLanguages());
+        commandManager.getCommandCompletions().registerCompletion("supported-lang", _ -> languageManager.getSupportedLanguages());
 
         registerListeners();
         Util.init(this);
@@ -118,5 +119,11 @@ public class FarmAssistReboot extends JavaPlugin {
 
     public void setNewVersion(String newVersion) {
         this.newVersion = newVersion;
+    }
+
+    @Override
+    public void onDisable() {
+        Util.cleanup();
+        paperLib.scheduling().cancelGlobalTasks();
     }
 }

--- a/src/main/java/com/github/sarhatabaot/farmassistreboot/Util.java
+++ b/src/main/java/com/github/sarhatabaot/farmassistreboot/Util.java
@@ -14,6 +14,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
@@ -31,6 +32,10 @@ public class Util {
 
     public static void init(final FarmAssistReboot plugin) {
         Util.plugin = plugin;
+    }
+
+    public static void cleanup() {
+        Util.plugin = null;
     }
 
     /**
@@ -55,13 +60,14 @@ public class Util {
                 .filter(p -> {
                     if (plugin.getAssistConfig().ignoreRenamed()) {
                         ItemStack itemStack = p.getValue();
-                        return itemStack.getItemMeta() != null && !itemStack.getItemMeta().hasDisplayName();
+                        ItemMeta meta = itemStack.getItemMeta();
+                        return meta == null || !meta.hasDisplayName();
                     }
                     return true;
                 })
                 .filter(p -> {
                     if (plugin.getAssistConfig().ignoreNbt()) {
-                        return NBT.get(p.getValue(), ReadableItemNBT::hasNBTData);
+                        return !NBT.get(p.getValue(), ReadableItemNBT::hasNBTData);
                     }
                     return true;
                 })

--- a/src/main/java/com/github/sarhatabaot/farmassistreboot/config/FarmAssistConfig.java
+++ b/src/main/java/com/github/sarhatabaot/farmassistreboot/config/FarmAssistConfig.java
@@ -4,7 +4,6 @@ import com.github.sarhatabaot.farmassistreboot.FarmAssistReboot;
 import dev.dejvokep.boostedyaml.YamlDocument;
 import dev.dejvokep.boostedyaml.route.Route;
 import dev.dejvokep.boostedyaml.settings.loader.LoaderSettings;
-import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.jetbrains.annotations.NotNull;
 
@@ -25,7 +24,9 @@ public class FarmAssistConfig {
                             .setAutoUpdate(true)
                             .build());
         } catch (IOException e) {
-            this.plugin.getLogger().severe("Failed to load config.yml");
+            this.plugin.getLogger().severe("Failed to load config.yml: " + e.getMessage());
+            this.plugin.getServer().getPluginManager().disablePlugin(this.plugin);
+            return;
         }
     }
 
@@ -85,7 +86,7 @@ public class FarmAssistConfig {
     }
 
     public boolean noSeeds() {
-        return config.getBoolean(Route.from("no-seeds", false));
+        return config.getBoolean(Route.from("no-seeds"), false);
     }
 
     public boolean noDrops() {
@@ -93,13 +94,7 @@ public class FarmAssistConfig {
     }
 
     private @NotNull Set<String> getWorlds() {
-        HashSet<String> enableWorlds = new HashSet<>();
-        for (String world: config.getStringList(Route.from("worlds", "enabled-worlds"))) {
-            if (Bukkit.getWorld(world) != null) {
-                enableWorlds.add(world);
-            }
-        }
-        return enableWorlds;
+        return new HashSet<>(config.getStringList(Route.from("worlds", "enabled-worlds")));
     }
 
     public boolean getRipe(@NotNull Material material) {

--- a/src/main/java/com/github/sarhatabaot/farmassistreboot/lang/LanguageManager.java
+++ b/src/main/java/com/github/sarhatabaot/farmassistreboot/lang/LanguageManager.java
@@ -66,7 +66,7 @@ public class LanguageManager {
                     }
                 }
             } catch (IOException e) {
-                //
+                plugin.getLogger().warning("Failed to read languages from jar: " + e.getMessage());
             }
         }
         return fileNames;

--- a/src/main/java/com/github/sarhatabaot/farmassistreboot/listeners/BlockBreakListener.java
+++ b/src/main/java/com/github/sarhatabaot/farmassistreboot/listeners/BlockBreakListener.java
@@ -94,16 +94,6 @@ public class BlockBreakListener implements Listener {
             return;
         }
 
-        if (Util.checkNoDrops(player)) {
-            final XMaterial seed = Crop.valueOf(material.name()).getSeed();
-            final Collection<ItemStack> items = event.getBlock().getDrops().stream()
-                    .filter(itemStack -> itemStack.getType() != seed.get())
-                    .collect(Collectors.toList());
-
-            dropItemsNaturally(event.getBlock().getLocation(), items);
-            event.setDropItems(false);
-        }
-
         if (material == Material.SUGAR_CANE || material == Material.CACTUS) {
             Util.replant(player, event.getBlock(), material);
             return;
@@ -112,14 +102,28 @@ public class BlockBreakListener implements Listener {
         if (!plugin.getAssistConfig().getRipe(material) || isRipe(event.getBlock())) {
             debug(String.format("isRipeConfig %s: ", material) + plugin.getAssistConfig().getRipe(material));
             debug(String.format("isRipe %s: ", material) + isRipe(event.getBlock()));
+
+            if (Util.checkNoDrops(player)) {
+                final Material seedMaterial = Crop.valueOf(material.name()).getSeed().parseMaterial();
+                final Collection<ItemStack> items = event.getBlock().getDrops().stream()
+                        .filter(itemStack -> seedMaterial == null || itemStack.getType() != seedMaterial)
+                        .collect(Collectors.toList());
+                dropItemsNaturally(event.getBlock().getLocation(), items);
+                event.setDropItems(false);
+            }
+
             Util.replant(player, event.getBlock(), slot);
         }
     }
 
 
     private boolean isRipe(@NotNull Block block) {
-        Ageable age = (Ageable) block.getBlockData();
-        return (age.getAge() == age.getMaximumAge());
+        final org.bukkit.block.data.BlockData data = block.getBlockData();
+        if (!(data instanceof Ageable)) {
+            return false;
+        }
+        final Ageable age = (Ageable) data;
+        return age.getAge() == age.getMaximumAge();
     }
 
     private void debug(final String message, Object... args) {

--- a/src/main/java/com/github/sarhatabaot/farmassistreboot/listeners/PlayerInteractionListener.java
+++ b/src/main/java/com/github/sarhatabaot/farmassistreboot/listeners/PlayerInteractionListener.java
@@ -72,7 +72,7 @@ public class PlayerInteractionListener implements Listener {
     }
 
     private boolean doesNotHaveWheatAndTillPermissions(final Player player) {
-        return plugin.getAssistConfig().usePermissions() && (!player.hasPermission(Permissions.WHEAT)) || !player.hasPermission(Permissions.TILL);
+        return plugin.getAssistConfig().usePermissions() && (!player.hasPermission(Permissions.WHEAT) || !player.hasPermission(Permissions.TILL));
     }
 
 

--- a/src/main/java/com/github/sarhatabaot/farmassistreboot/tasks/ReplantTask.java
+++ b/src/main/java/com/github/sarhatabaot/farmassistreboot/tasks/ReplantTask.java
@@ -30,8 +30,11 @@ public class ReplantTask implements Runnable {
         this.material = block.getType();
 
         if (XMaterial.matchXMaterial(block.getType()) == XMaterial.COCOA) {
-            this.cocoa = (Cocoa) block.getBlockData().clone();
-            this.cocoa.setAge(0);
+            final BlockData data = block.getBlockData();
+            if (data instanceof Cocoa) {
+                this.cocoa = (Cocoa) data.clone();
+                this.cocoa.setAge(0);
+            }
         }
     }
 
@@ -64,6 +67,11 @@ public class ReplantTask implements Runnable {
 
     private void setCocoaOrDropSeed() {
         if (this.block.getType() != Material.AIR) {
+            return;
+        }
+
+        if (cocoa == null) {
+            this.block.getWorld().dropItemNaturally(this.block.getLocation(), new ItemStack(Material.COCOA_BEANS));
             return;
         }
 
@@ -109,8 +117,10 @@ public class ReplantTask implements Runnable {
     }
 
     private @NotNull BlockData setCropAge() {
-        Ageable age = (Ageable) this.block.getBlockData();
-        age.setAge(0);
-        return age;
+        final BlockData data = this.block.getBlockData();
+        if (data instanceof Ageable) {
+            ((Ageable) data).setAge(0);
+        }
+        return data;
     }
 }

--- a/src/main/java/com/github/sarhatabaot/farmassistreboot/tasks/SimpleUpdateCheckerTask.java
+++ b/src/main/java/com/github/sarhatabaot/farmassistreboot/tasks/SimpleUpdateCheckerTask.java
@@ -37,7 +37,12 @@ public class SimpleUpdateCheckerTask implements Runnable {
             try(BufferedReader in = new BufferedReader(new InputStreamReader(urlConnection.getInputStream()))) {
                 Object obj = parser.parse(in);
                 JSONObject jsonObject = (JSONObject) obj;
-                final String remoteVer = ((String) jsonObject.get("tag_name")).replace("v", "");
+                final Object tagNameObj = jsonObject.get("tag_name");
+                if (tagNameObj == null) {
+                    plugin.getLogger().warning("Update check failed: 'tag_name' missing from GitHub API response.");
+                    return;
+                }
+                final String remoteVer = ((String) tagNameObj).replace("v", "");
                 int remoteVal = Integer.parseInt(remoteVer.replace(".", ""));
                 int localVer = Integer.parseInt(versionNumber.replace(".", ""));
                 if (remoteVal > localVer) {


### PR DESCRIPTION
## Summary

- **`PITCHER_PLANT` → `PITCHER_CROP`** (`Crop.java`): enum-константа не совпадала с именем материала `Material.PITCHER_CROP`, что вызывало `IllegalArgumentException` при каждом сборе Pitcher Plant
- **Приоритет операторов** (`PlayerInteractionListener.java`): `&&` / `||` вычислялись некорректно — проверка TILL-разрешения срабатывала даже когда `use-permissions=false`
- **`ignoreNbt` фильтр** (`Util.java`): логика была инвертирована — оставлял семена **с** NBT вместо того, чтобы их пропускать
- **`ignoreRenamed` фильтр** (`Util.java`): семена без `ItemMeta` (без кастомного имени) неверно отфильтровывались
- **`noDrops` до проверки зрелости** (`BlockBreakListener.java`): дропы перехватывались до `isRipe()`, из-за чего при незрелом урожае дропы менялись, но пересадка не происходила — перенесено внутрь ripe-блока
- **`seed.get()` без null-проверки** (`BlockBreakListener.java`): заменено на `seed.parseMaterial()` с null-safe фильтром
- **`ClassCastException` в `isRipe` / `setCropAge`** (`BlockBreakListener.java`, `ReplantTask.java`): добавлена проверка `instanceof Ageable` перед приведением типа
- **NPE в `ReplantTask` (какао)**: добавлена проверка `instanceof Cocoa` и null-guard для `cocoa`
- **`noSeeds()` неверный Route** (`FarmAssistConfig.java`): `false` передавался как часть Route вместо значения по умолчанию
- **`getWorlds()` фильтр по `Bukkit.getWorld()`** (`FarmAssistConfig.java`): убран фильтр, который исключал миры, не загруженные в момент чтения конфига
- **Null-check `tag_name`** (`SimpleUpdateCheckerTask.java`): добавлена проверка перед разбором ответа GitHub API
- **Thread safety** (`FarmAssistReboot.java`): поля `globalEnabled`, `needsUpdate`, `newVersion` помечены `volatile`; `ArrayList` заменён на `CopyOnWriteArrayList`
- **`FarmAssistPlaceholderExpansion`**: исправлен `split("_")` → `split("_", 2)` для корректной обработки имён игроков с `_`
- **`LanguageManager`**: пустой `catch` заменён логированием
- Обновлён toolchain Java 8 → 25, добавлен `qodana.yaml` для статического анализа

## Test plan

- [ ] Сломать зрелый Pitcher Plant — убедиться, что пересаживается без исключений
- [ ] Сломать незрелый урожай при `replant-when-ripe: true` и `no-drops: true` — дропы не должны изменяться
- [ ] Отключить `use-permissions`, убедиться что тяпка работает без TILL-разрешения
- [ ] Протестировать семена с NBT при `ignore-seeds.nbt: true` — не должны использоваться для пересадки
- [ ] Протестировать семена с кастомным именем при `ignore-seeds.renamed: true` — не должны использоваться

🤖 Generated with [Claude Code](https://claude.com/claude-code)